### PR TITLE
Add auth guards for admin areas

### DIFF
--- a/src/pages/AdminService.tsx
+++ b/src/pages/AdminService.tsx
@@ -1,5 +1,5 @@
 import '../styles/globals.css';
-import React from "react";
+import React, { useEffect } from "react";
 import { useAuth } from "../context/AuthContext";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -7,7 +7,17 @@ import EventReview from '@/components/EventReview';
 
 const AdminService: React.FC = () => {
   const router = useRouter();
-  const { user, logout } = useAuth();
+  const { user, logout, loading } = useAuth();
+
+  useEffect(() => {
+    if (!loading) {
+      if (!user) {
+        router.replace('/LoginPage?redirect=/AdminService');
+      } else if (!user.is_admin) {
+        router.replace('/');
+      }
+    }
+  }, [user, loading, router]);
 
   const handleLogout = async () => {
     try {

--- a/src/pages/AdminUsersPage.tsx
+++ b/src/pages/AdminUsersPage.tsx
@@ -13,8 +13,18 @@ const AdminUsersPage = () => {
   const [users, setUsers] = useState<Users>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
-  const { user: currentUser, logout } = useAuth();
+  const { user: currentUser, logout, loading } = useAuth();
   const router = useRouter();
+
+  useEffect(() => {
+    if (!loading) {
+      if (!currentUser) {
+        router.replace('/LoginPage?redirect=/AdminUsersPage');
+      } else if (!currentUser.is_admin) {
+        router.replace('/');
+      }
+    }
+  }, [currentUser, loading, router]);
 
   useEffect(() => {
     const fetchUsers = async () => {

--- a/src/pages/events/edit/[editId].tsx
+++ b/src/pages/events/edit/[editId].tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { Event } from '@/interfaces/interfaces';
 import Header from '@/components/Header';
 import Link from 'next/link';
+import { useAuth } from '@/context/AuthContext';
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL!;
 
 const EditEventPage = () => {
@@ -11,11 +12,28 @@ const EditEventPage = () => {
   const router = useRouter();
   const { editId } = router.query;          // ← string | string[] | undefined
 
+  const { user, loading } = useAuth();
+
   /* ── local state (hooks MUST be first) ─────────────── */
   const [eventData, setEventData] = useState<Event | null>(null);
   const [file,       setFile]       = useState<File | null>(null);
   const [removePoster, setRemovePoster] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      const redirect = editId ? `/events/edit/${editId}` : '/events/edit';
+      router.replace(`/LoginPage?redirect=${redirect}`);
+    }
+  }, [user, loading, router, editId]);
+
+  useEffect(() => {
+    if (!loading && user && eventData) {
+      if (!(user.is_admin || user.id === eventData.user_id)) {
+        router.replace('/');
+      }
+    }
+  }, [loading, user, eventData, router]);
 
   /* ── fetch event once router & param are ready ─────── */
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure admin pages redirect unauthorized users
- block unauthorized users from editing events

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479839896c832ca368084a9c983610