### PR TITLE
Add trial helper

### DIFF
--- a/src/pages/artists/[slug].tsx
+++ b/src/pages/artists/[slug].tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/context/AuthContext';
 import Header from '@/components/Header';
 import Link from 'next/link';
 import TrialBanner from '@/components/TrialBanner'; // adjust path as needed
+import { isTrialActive } from '@/util/trial';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
@@ -91,7 +92,8 @@ const ArtistProfilePage = ({ artist }: Props) => {
 
   if (!artist) return <div className="text-white p-6">Artist not found</div>;
 
-  const shouldShowUpgradeWall = (!artist.is_pro && (artist.trial_expired || !artist.trial_ends_at));
+  const trialActive = isTrialActive(artist.trial_ends_at);
+  const shouldShowUpgradeWall = !artist.is_pro && !trialActive;
 
 if (shouldShowUpgradeWall) {
   return (

--- a/src/pages/eventSubmission.tsx
+++ b/src/pages/eventSubmission.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import Script from "next/script";
 import { slugify } from '@/util/slugify'; // Adjust path if needed
-import dayjs from 'dayjs';
+import { isTrialActive } from '@/util/trial';
 import EventForm from '../components/EventForm';
 
 interface Event {
@@ -63,8 +63,8 @@ const EventSubmission = () => {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const isPro = user?.is_pro;
-  const isTrialActive = user?.trial_ends_at ? dayjs().isBefore(dayjs(user.trial_ends_at)) : false;
-  const canAddMultiple = Boolean(isPro || isTrialActive);
+  const trialActive = isTrialActive(user?.trial_ends_at);
+  const canAddMultiple = Boolean(isPro || trialActive);
 
   const addEvent = () => setEvents((prev) => [...prev, { ...initialEvent }]);
   const removeEvent = (index: number) =>

--- a/src/util/trial.ts
+++ b/src/util/trial.ts
@@ -1,0 +1,4 @@
+import dayjs from 'dayjs';
+
+export const isTrialActive = (trialEndsAt?: string | null) =>
+  !!trialEndsAt && dayjs().isBefore(dayjs(trialEndsAt));


### PR DESCRIPTION
## Summary
- add helper to check if a trial is active
- use helper in event submission and artist pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce5fbd7ac832c8d1274da113ced80