### PR TITLE
Show banner when artist profile missing

### DIFF
--- a/src/components/ActiveTrialNoProfileBanner.tsx
+++ b/src/components/ActiveTrialNoProfileBanner.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ActiveTrialNoProfileBanner: React.FC = () => {
+  return (
+    <div className="rounded-md p-3 text-white text-center shadow-md mb-4 text-sm font-medium bg-orange-700">
+      🎁 <span className="font-semibold">Alpine Pro trial active:</span> Create or restore your artist profile to access the dashboard.
+    </div>
+  );
+};
+
+export default ActiveTrialNoProfileBanner;

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -4,6 +4,8 @@ import React, { useState, useEffect } from "react";
 import Header from "@/components/Header";
 import Image from "next/image";
 import TrialBanner from '@/components/TrialBanner';
+import ActiveTrialNoProfileBanner from '@/components/ActiveTrialNoProfileBanner';
+import { isTrialActive } from '@/util/isTrialActive';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -30,6 +32,7 @@ const UserProfile: React.FC = () => {
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const [hasRefetched, setHasRefetched] = useState(false);
+  const trialActive = isTrialActive(user?.trial_ends_at);
 
   // If redirected from Stripe, fetch updated user info
   useEffect(() => {
@@ -184,6 +187,7 @@ const UserProfile: React.FC = () => {
     <div className="min-h-screen bg-gray-900 text-white">
       <Header />
       <TrialBanner />
+      {trialActive && !hasArtistProfile && <ActiveTrialNoProfileBanner />}
       {showSuccessToast && (
         <div className="bg-green-600 text-white text-sm text-center px-4 py-2 rounded shadow mb-4 max-w-xl mx-auto">
           ✅ Success! You’ve unlocked Alpine Pro.
@@ -311,6 +315,14 @@ const UserProfile: React.FC = () => {
                   >
                     🎁 Create Pro Artist Profile (Free Trial)
                   </button>
+                  {trialActive && (
+                    <button
+                      onClick={() => router.push("/artist-restore")}
+                      className="bg-blue-600 hover:bg-blue-700 text-white py-2 rounded font-semibold mt-2"
+                    >
+                      Restore Profile
+                    </button>
+                  )}
                   <p className="text-xs text-gray-400 mt-1">
                     Get 30 days of free access to Alpine Pro features — no credit card required.
                   </p>


### PR DESCRIPTION
## Summary
- display an orange banner if a user has an active trial but no artist profile
- add optional **Restore Profile** button when trial is active

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce8a31a90832cb863f1c236e3ed97