### PR TITLE
Add artist profile restore page

### DIFF
--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -175,31 +175,6 @@ const UserProfile: React.FC = () => {
     }
   };
 
-  const handleRestoreProfile = async () => {
-    if (!user) return;
-
-    try {
-      const res = await fetch(`${API_BASE_URL}/api/artists/${user.id}/restore`, {
-        method: 'PUT',
-        credentials: 'include',
-      });
-
-      if (!res.ok) {
-        const errData = await res.json().catch(() => null);
-        const errorMsg = errData?.message || 'Failed to restore profile';
-        setMessage(errorMsg);
-        return;
-      }
-
-      const data = await res.json();
-      setHasArtistProfile(true);
-      setArtistSlug(data.slug);
-      setMessage('Profile restored successfully!');
-    } catch (err) {
-      console.error('Restore profile error:', err);
-      setMessage('An error occurred while restoring your profile.');
-    }
-  };
 
   if (loading || !hasRefetched) {
     return <div className="text-white text-center mt-20">Loading your profile...</div>;
@@ -343,7 +318,7 @@ const UserProfile: React.FC = () => {
                   </button>
                   {trialActive && (
                     <button
-                      onClick={handleRestoreProfile}
+                      onClick={() => router.push('/artist-restore')}
                       className="bg-blue-600 hover:bg-blue-700 text-white py-2 rounded font-semibold mt-2"
                     >
                       Restore Profile

--- a/src/pages/artist-restore.tsx
+++ b/src/pages/artist-restore.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from '@/context/AuthContext';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export default function ArtistRestorePage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (loading) return;
+    if (!user) {
+      router.replace('/LoginPage?redirect=/artist-restore');
+      return;
+    }
+
+    const restore = async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/artists/${user.id}/restore`, {
+          method: 'PUT',
+          credentials: 'include',
+        });
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          setError(data?.message || 'Failed to restore profile.');
+          return;
+        }
+
+        const data = await res.json();
+        const slug = data.slug;
+        if (slug) {
+          router.replace(`/artists/${slug}`);
+        } else {
+          setMessage('Profile restored successfully!');
+        }
+      } catch (err) {
+        console.error('Restore profile error:', err);
+        setError('An error occurred while restoring your profile.');
+      }
+    };
+
+    restore();
+  }, [loading, user, router]);
+
+  if (loading) {
+    return <div className="text-white text-center mt-20">Loading...</div>;
+  }
+
+  return (
+    <div className="text-white text-center mt-20">
+      {error && <p className="text-red-400">{error}</p>}
+      {message && <p>{message}</p>}
+      {!error && !message && <p>Restoring your profile...</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `artist-restore.tsx` page that automatically restores an artist profile
- link the "Restore Profile" button in `UserProfile` to the new page and remove the old inline logic

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf54f95b4832c8632b2c1b9ab7e58