### PR TITLE
Implement artist admin review

### DIFF
--- a/src/components/AdminArtistCard.tsx
+++ b/src/components/AdminArtistCard.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+import { Artist } from '../interfaces/interfaces';
+
+interface Props {
+  artist: Artist;
+  onApprove: () => void;
+  onDeny: () => void;
+  onSave: (updated: Artist) => void;
+}
+
+const AdminArtistCard: React.FC<Props> = ({ artist, onApprove, onDeny, onSave }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [edited, setEdited] = useState<Artist>(artist);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setEdited(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setEdited(prev => ({ ...prev, profile_image: reader.result as string }));
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSaveClick = () => {
+    onSave(edited);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="bg-white rounded-md shadow-md text-black p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold flex items-center gap-1">
+          🎵 {artist.display_name}
+        </h3>
+        <button onClick={() => setIsExpanded(!isExpanded)} className="text-blue-600 underline">
+          {isExpanded ? 'Hide' : 'See More'}
+        </button>
+      </div>
+      {isExpanded && (
+        <div className="mt-4 space-y-4">
+          {edited.profile_image && (
+            <Image src={edited.profile_image} alt="Profile" width={150} height={150} className="rounded" />
+          )}
+          {isEditing && (
+            <input type="file" accept="image/*" onChange={handleFileChange} className="w-full" />
+          )}
+          <div>
+            <label className="block text-sm font-medium">Display Name</label>
+            <input
+              type="text"
+              name="display_name"
+              value={edited.display_name}
+              onChange={handleChange}
+              disabled={!isEditing}
+              className="mt-1 p-2 border rounded w-full"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Bio</label>
+            <textarea
+              name="bio"
+              value={edited.bio}
+              onChange={handleChange}
+              disabled={!isEditing}
+              className="mt-1 p-2 border rounded w-full"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Contact Email</label>
+            <input
+              type="email"
+              name="contact_email"
+              value={edited.contact_email}
+              onChange={handleChange}
+              disabled={!isEditing}
+              className="mt-1 p-2 border rounded w-full"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Website</label>
+            <input
+              type="text"
+              name="website"
+              value={edited.website || ''}
+              onChange={handleChange}
+              disabled={!isEditing}
+              className="mt-1 p-2 border rounded w-full"
+            />
+          </div>
+          <div className="flex gap-2 justify-end">
+            {isEditing ? (
+              <button onClick={handleSaveClick} className="bg-green-600 text-white px-3 py-1 rounded">
+                Save
+              </button>
+            ) : (
+              <button onClick={() => setIsEditing(true)} className="bg-blue-600 text-white px-3 py-1 rounded">
+                Edit
+              </button>
+            )}
+            <button onClick={onApprove} className="bg-emerald-500 text-white px-3 py-1 rounded">
+              Approve
+            </button>
+            <button onClick={onDeny} className="bg-red-600 text-white px-3 py-1 rounded">
+              Deny
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminArtistCard;

--- a/src/components/AdminEventCard.tsx
+++ b/src/components/AdminEventCard.tsx
@@ -11,6 +11,7 @@ interface AdminEventCardProps {
 
 const AdminEventCard: React.FC<AdminEventCardProps> = ({ event, onApprove, onDeny, onSave }) => {
   const [isEditing, setIsEditing] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [editedEvent, setEditedEvent] = useState(event);
   const [formattedDate, setFormattedDate] = useState('');
   const [formattedStartTime, setFormattedStartTime] = useState('');
@@ -34,6 +35,17 @@ const AdminEventCard: React.FC<AdminEventCardProps> = ({ event, onApprove, onDen
     }));
   };
 
+  const handlePosterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setEditedEvent(prev => ({ ...prev, poster: reader.result as string }));
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
   const handleApproveClick = async () => {
     setIsApproving(true);
     try {
@@ -51,44 +63,56 @@ const AdminEventCard: React.FC<AdminEventCardProps> = ({ event, onApprove, onDen
 
   return (
     <div className="flex flex-col space-y-6 p-6 border border-gray-200 rounded-lg shadow-md bg-white">
-      {/* Submitter Info */}
-      {event.user && (
-        <div>
-          <p className="text-sm text-gray-600">Submitted by:</p>
-          <p className="text-black font-medium">{event.user.first_name} {event.user.last_name}</p>
-          <p className="text-gray-500 text-sm">{event.user.email}</p>
-        </div>
-      )}
-
-      {/* Poster */}
-      {event.poster ? (
-        <div className="w-full">
-          <p className="text-sm font-medium text-gray-700 mb-1">Poster Image</p>
-          <Image
-            src={event.poster}
-            alt="Event Poster"
-            width={400}
-            height={400}
-            className="rounded-md mx-auto"
-          />
-        </div>
-      ) : (
-        <p className="text-center text-gray-400">No poster uploaded.</p>
-      )}
-
-      {/* Title */}
-      <div>
-        <label htmlFor="title" className="text-sm font-medium text-gray-700">Title</label>
-        <input
-          type="text"
-          id="title"
-          name="title"
-          value={editedEvent.title}
-          onChange={handleChange}
-          disabled={!isEditing}
-          className={`mt-1 p-3 border w-full rounded-md text-black ${isEditing ? 'bg-white' : 'bg-gray-100'}`}
-        />
+      <div className="flex justify-between items-start">
+        <h3 className="font-semibold text-black">{event.title}</h3>
+        <button onClick={() => setIsExpanded(!isExpanded)} className="text-blue-600 underline">
+          {isExpanded ? 'Hide' : 'See More'}
+        </button>
       </div>
+      {isExpanded && (
+        <>
+          {/* Submitter Info */}
+          {event.user && (
+            <div>
+              <p className="text-sm text-gray-600">Submitted by:</p>
+              <p className="text-black font-medium">{event.user.first_name} {event.user.last_name}</p>
+              <p className="text-gray-500 text-sm">{event.user.email}</p>
+            </div>
+          )}
+
+          {/* Poster */}
+          {editedEvent.poster ? (
+            <div className="w-full">
+              <p className="text-sm font-medium text-gray-700 mb-1">Poster Image</p>
+              <Image src={editedEvent.poster} alt="Event Poster" width={400} height={400} className="rounded-md mx-auto" />
+              {isEditing && (
+                <button onClick={() => setEditedEvent(prev => ({ ...prev, poster: null }))} className="text-red-600 underline mt-1">
+                  Remove Photo
+                </button>
+              )}
+            </div>
+          ) : (
+            <div>
+              <p className="text-center text-gray-400">No poster uploaded.</p>
+              {isEditing && (
+                <input type="file" accept="image/*" onChange={handlePosterChange} className="mt-2" />
+              )}
+            </div>
+          )}
+
+          {/* Title */}
+          <div>
+            <label htmlFor="title" className="text-sm font-medium text-gray-700">Title</label>
+            <input
+              type="text"
+              id="title"
+              name="title"
+              value={editedEvent.title}
+              onChange={handleChange}
+              disabled={!isEditing}
+              className={`mt-1 p-3 border w-full rounded-md text-black ${isEditing ? 'bg-white' : 'bg-gray-100'}`}
+            />
+          </div>
 
       {/* Description */}
       <div>
@@ -228,45 +252,47 @@ const AdminEventCard: React.FC<AdminEventCardProps> = ({ event, onApprove, onDen
         </div>
       )}
 
-      {/* Actions */}
-      <div className="flex flex-wrap justify-end gap-3 mt-6">
-        {isEditing ? (
-          <button
-            onClick={handleSaveClick}
-            className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md"
-          >
-            Save
-          </button>
-        ) : (
-          <button
-            onClick={handleEditClick}
-            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md"
-          >
-            Edit
-          </button>
-        )}
-        <button
-          onClick={handleApproveClick}
-          className="bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2 rounded-md flex items-center justify-center min-w-[100px]"
-          disabled={isApproving}
-        >
-          {isApproving ? (
-            <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
-            </svg>
-          ) : (
-            "Approve"
-          )}
-        </button>
+          {/* Actions */}
+          <div className="flex flex-wrap justify-end gap-3 mt-6">
+            {isEditing ? (
+              <button
+                onClick={handleSaveClick}
+                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-md"
+              >
+                Save
+              </button>
+            ) : (
+              <button
+                onClick={handleEditClick}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md"
+              >
+                Edit
+              </button>
+            )}
+            <button
+              onClick={handleApproveClick}
+              className="bg-emerald-500 hover:bg-emerald-600 text-white px-4 py-2 rounded-md flex items-center justify-center min-w-[100px]"
+              disabled={isApproving}
+            >
+              {isApproving ? (
+                <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"></path>
+                </svg>
+              ) : (
+                "Approve"
+              )}
+            </button>
 
-        <button
-          onClick={onDeny}
-          className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md"
-        >
-          Deny
-        </button>
-      </div>
+            <button
+              onClick={onDeny}
+              className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md"
+            >
+              Deny
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/ArtistReview.tsx
+++ b/src/components/ArtistReview.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useEffect, useState } from 'react';
+import AdminArtistCard from './AdminArtistCard';
+import { getPendingArtists, approveArtist, deleteArtist, updateArtist } from '@/pages/api/artists';
+import { Artist, Artists } from '@/interfaces/interfaces';
+
+const ArtistReview: React.FC = () => {
+  const [artists, setArtists] = useState<Artists>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getPendingArtists();
+        setArtists(data);
+      } catch (err) {
+        console.error('Failed to load artists for review', err);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleApprove = async (id: number) => {
+    try {
+      await approveArtist(id);
+      setArtists(prev => prev.filter(a => a.id !== id));
+    } catch (err) {
+      console.error('Approve error', err);
+    }
+  };
+
+  const handleDeny = async (slug: string) => {
+    try {
+      await deleteArtist(slug);
+      setArtists(prev => prev.filter(a => a.slug !== slug));
+    } catch (err) {
+      console.error('Delete error', err);
+    }
+  };
+
+  const handleSave = async (updated: Artist) => {
+    try {
+      await updateArtist(updated.slug, updated);
+      setArtists(prev => prev.map(a => (a.id === updated.id ? updated : a)));
+    } catch (err) {
+      console.error('Save error', err);
+    }
+  };
+
+  return (
+    <div className="mt-8">
+      {artists.length > 0 ? (
+        <ul className="space-y-6">
+          {artists.map(a => (
+            <li key={a.id} className="bg-white rounded-md shadow-md p-4">
+              <AdminArtistCard
+                artist={a}
+                onApprove={() => handleApprove(a.id)}
+                onDeny={() => handleDeny(a.slug)}
+                onSave={handleSave}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="text-center text-gray-300 py-10">
+          <p className="text-lg">✅ All clear — no pending artists right now.</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ArtistReview;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -69,4 +69,19 @@ interface User {
 export type Users = User[];
 export type Events = Event[];
 
+export interface Artist {
+  id: number;
+  display_name: string;
+  user_id: number;
+  bio: string;
+  contact_email: string;
+  profile_image: string | null;
+  website?: string;
+  genres: string[];
+  slug: string;
+  is_approved?: boolean;
+}
+
+export type Artists = Artist[];
+
 export type { User };

--- a/src/pages/AdminService.tsx
+++ b/src/pages/AdminService.tsx
@@ -4,10 +4,13 @@ import { useAuth } from "../context/AuthContext";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import EventReview from '@/components/EventReview';
+import ArtistReview from '@/components/ArtistReview';
+import { useState } from 'react';
 
 const AdminService: React.FC = () => {
   const router = useRouter();
   const { user, logout, loading } = useAuth();
+  const [view, setView] = useState<'events' | 'artists'>('events');
 
   useEffect(() => {
     if (!loading) {
@@ -38,7 +41,22 @@ const AdminService: React.FC = () => {
           You’re an admin for Alpine Groove Guide. Review pending events for grammar, clarity, and content.
         </p>
 
-        <EventReview />
+        <div className="flex justify-center gap-4 mt-6">
+          <button
+            onClick={() => setView('events')}
+            className={`px-4 py-2 rounded ${view === 'events' ? 'bg-gold text-black' : 'bg-gray-700'}`}
+          >
+            🗓 Events
+          </button>
+          <button
+            onClick={() => setView('artists')}
+            className={`px-4 py-2 rounded ${view === 'artists' ? 'bg-gold text-black' : 'bg-gray-700'}`}
+          >
+            🎵 Artists
+          </button>
+        </div>
+
+        {view === 'events' ? <EventReview /> : <ArtistReview />}
 
         <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-8">
           <Link href="/" className="bg-gold hover:bg-yellow-500 text-black font-semibold py-2 px-4 rounded">

--- a/src/pages/api/artists.ts
+++ b/src/pages/api/artists.ts
@@ -28,3 +28,49 @@ export async function getArtistBySlug(slug: string) {
 
   return response.json();
 }
+
+export async function getPendingArtists() {
+  const res = await fetch(`${API_BASE_URL}/api/artists/pending`, {
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to fetch pending artists');
+  }
+  return res.json();
+}
+
+export async function approveArtist(id: number) {
+  const res = await fetch(`${API_BASE_URL}/api/artists/${id}/approve`, {
+    method: 'PUT',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to approve artist');
+  }
+  return res.json();
+}
+
+export async function deleteArtist(slug: string) {
+  const res = await fetch(`${API_BASE_URL}/api/artists/${slug}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.message || 'Failed to delete artist');
+  }
+}
+
+export async function updateArtist(slug: string, artistData: any) {
+  const res = await fetch(`${API_BASE_URL}/api/artists/${slug}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(artistData),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.message || 'Failed to update artist');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add artist admin endpoints and types
- create `AdminArtistCard` and `ArtistReview` components
- collapse event review cards and support poster editing
- allow toggling between event and artist review in admin page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0e40d2b0832cb10e20ce3e445f93