### PR TITLE
Fix admin artist review endpoints

### DIFF
--- a/src/pages/api/artists.ts
+++ b/src/pages/api/artists.ts
@@ -30,7 +30,7 @@ export async function getArtistBySlug(slug: string) {
 }
 
 export async function getPendingArtists() {
-  const res = await fetch(`${API_BASE_URL}/api/artists/pending`, {
+  const res = await fetch(`${API_BASE_URL}/api/artists/review`, {
     credentials: 'include',
   });
   if (!res.ok) {
@@ -40,7 +40,7 @@ export async function getPendingArtists() {
 }
 
 export async function approveArtist(id: number) {
-  const res = await fetch(`${API_BASE_URL}/api/artists/${id}/approve`, {
+  const res = await fetch(`${API_BASE_URL}/api/artists/review/${id}`, {
     method: 'PUT',
     credentials: 'include',
   });


### PR DESCRIPTION
## Summary
- fix the endpoint used to fetch pending artists
- update artist approval call to use `artists/review/:id`

## Testing
- `npm test --silent` *(fails: `CONNECT registry.npmjs.org:443`)*
- `npm run lint --silent` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d1d28cf4c832cb30a46dba508f823