### PR TITLE
Fix pending artists endpoint path

### DIFF
--- a/src/pages/api/artists.ts
+++ b/src/pages/api/artists.ts
@@ -30,7 +30,7 @@ export async function getArtistBySlug(slug: string) {
 }
 
 export async function getPendingArtists() {
-  const res = await fetch(`${API_BASE_URL}/api/artists/review`, {
+  const res = await fetch(`${API_BASE_URL}/api/artists/pending`, {
     credentials: 'include',
   });
   if (!res.ok) {
@@ -40,7 +40,7 @@ export async function getPendingArtists() {
 }
 
 export async function approveArtist(id: number) {
-  const res = await fetch(`${API_BASE_URL}/api/artists/review/${id}`, {
+  const res = await fetch(`${API_BASE_URL}/api/artists/${id}/approve`, {
     method: 'PUT',
     credentials: 'include',
   });


### PR DESCRIPTION
## Summary
- fix API paths for pending artist review

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d21970c50832caa78f016a9d74b72