### PR TITLE
Fix artist approval workflow

### DIFF
--- a/src/pages/api/artists.ts
+++ b/src/pages/api/artists.ts
@@ -2,11 +2,15 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 
 export async function createArtistProfile(artistData: any) {
+  const payload = {
+    ...artistData,
+    is_approved: false,
+  };
   const response = await fetch(`${API_BASE_URL}/api/artists`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
-    body: JSON.stringify(artistData),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {

--- a/src/pages/artist-signup.tsx
+++ b/src/pages/artist-signup.tsx
@@ -105,6 +105,7 @@ export default function ArtistSignupPage() {
       });
 
       formData.append('is_pro', 'true');
+      formData.append('is_approved', 'false');
 
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/artists`, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- send `is_approved: false` when creating artists
- include `is_approved` flag in artist signup

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d27392d14832cacbf8b567691b1f1