### PR TITLE
Update signup redirect and add trial toast

### DIFF
--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -32,6 +32,7 @@ const UserProfile: React.FC = () => {
   const [checkoutLoading, setCheckoutLoading] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
   const [showApprovalToast, setShowApprovalToast] = useState(false);
+  const [showTrialToast, setShowTrialToast] = useState(false);
   const approvalRef = useRef<boolean | null>(null);
   const [hasRefetched, setHasRefetched] = useState(false);
   const trialActive = isTrialActive(user?.trial_ends_at);
@@ -119,6 +120,16 @@ const UserProfile: React.FC = () => {
       cleaned.searchParams.delete('approved');
       window.history.replaceState({}, document.title, cleaned.toString());
       setTimeout(() => setShowApprovalToast(false), 5000);
+    }
+  }, [router.query]);
+
+  useEffect(() => {
+    if (router.query.trial === 'active') {
+      setShowTrialToast(true);
+      const cleaned = new URL(window.location.href);
+      cleaned.searchParams.delete('trial');
+      window.history.replaceState({}, document.title, cleaned.toString());
+      setTimeout(() => setShowTrialToast(false), 5000);
     }
   }, [router.query]);
 
@@ -260,6 +271,11 @@ const UserProfile: React.FC = () => {
       {showApprovalToast && (
         <div className="bg-green-600 text-white text-sm text-center px-4 py-2 rounded shadow mb-4 max-w-xl mx-auto">
           🎉 You’re live on the directory!
+        </div>
+      )}
+      {showTrialToast && (
+        <div className="bg-green-600 text-white text-sm text-center px-4 py-2 rounded shadow mb-4 max-w-xl mx-auto">
+          ✅ Welcome! Your 30-day free trial of Alpine Pro is active.
         </div>
       )}
       <div className="max-w-5xl mx-auto p-6">

--- a/src/pages/artist-signup.tsx
+++ b/src/pages/artist-signup.tsx
@@ -116,7 +116,7 @@ export default function ArtistSignupPage() {
       if (!res.ok) throw new Error('Failed to create artist profile');
 
       const data = await res.json();
-      router.push(`/artists/${data.slug}?pending=true&trial=active`);
+      router.push(`/UserProfile?trial=active`);
     } catch (err: any) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- redirect artist signup to user profile instead of the new artist page
- show a trial toast on the user profile when `?trial=active` is present

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f54470cd0832cb146593456838339