### PR TITLE
Add admin notes and filters for artist review

### DIFF
--- a/src/components/AdminArtistCard.tsx
+++ b/src/components/AdminArtistCard.tsx
@@ -12,7 +12,7 @@ interface Props {
 const AdminArtistCard: React.FC<Props> = ({ artist, onApprove, onDeny, onSave }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [edited, setEdited] = useState<Artist>(artist);
+  const [edited, setEdited] = useState<Artist>({ ...artist });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -129,6 +129,17 @@ const AdminArtistCard: React.FC<Props> = ({ artist, onApprove, onDeny, onSave })
             </div>
           )}
 
+          <div>
+            <label className="block text-sm font-medium">Moderation Notes</label>
+            <textarea
+              name="notes"
+              value={edited.notes || ''}
+              onChange={handleChange}
+              className="mt-1 p-2 border rounded w-full"
+              rows={3}
+            />
+          </div>
+
           {edited.promo_photo && (
             <div>
               <label className="text-sm font-medium">Promo Photo</label>
@@ -190,6 +201,23 @@ const AdminArtistCard: React.FC<Props> = ({ artist, onApprove, onDeny, onSave })
               />
             </div>
           )}
+
+          <div className="flex gap-2 mt-2">
+            <a
+              href={`/artists/${artist.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline text-sm"
+            >
+              View Public Page
+            </a>
+            <a
+              href={`/artists/edit/${artist.slug}`}
+              className="text-blue-600 underline text-sm"
+            >
+              Edit
+            </a>
+          </div>
 
           {/* Action Buttons */}
           <div className="flex gap-2 justify-end mt-4">

--- a/src/components/ArtistReview.tsx
+++ b/src/components/ArtistReview.tsx
@@ -6,6 +6,9 @@ import { Artist, Artists } from '@/interfaces/interfaces';
 
 const ArtistReview: React.FC = () => {
   const [artists, setArtists] = useState<Artists>([]);
+  const [proFilter, setProFilter] = useState<'all' | 'true' | 'false'>('all');
+  const [approvedFilter, setApprovedFilter] = useState<'all' | 'true' | 'false'>('all');
+  const [sortOrder, setSortOrder] = useState<'newest' | 'oldest'>('newest');
 
   useEffect(() => {
     const fetchData = async () => {
@@ -50,11 +53,57 @@ const ArtistReview: React.FC = () => {
     }
   };
 
+  const filteredArtists = artists
+    .filter(a => (proFilter === 'all' || String(!!a.is_pro) === proFilter))
+    .filter(a => (approvedFilter === 'all' || String(!!a.is_approved) === approvedFilter))
+    .sort((a, b) => {
+      if (!a.created_at || !b.created_at) return 0;
+      const diff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      return sortOrder === 'oldest' ? diff : -diff;
+    });
+
   return (
     <div className="mt-8">
-      {artists.length > 0 ? (
+      <div className="flex flex-wrap gap-4 mb-4">
+        <div>
+          <label className="mr-2">Pro</label>
+          <select
+            value={proFilter}
+            onChange={e => setProFilter(e.target.value as 'all' | 'true' | 'false')}
+            className="text-black p-1 rounded"
+          >
+            <option value="all">All</option>
+            <option value="true">Pro</option>
+            <option value="false">Free</option>
+          </select>
+        </div>
+        <div>
+          <label className="mr-2">Approved</label>
+          <select
+            value={approvedFilter}
+            onChange={e => setApprovedFilter(e.target.value as 'all' | 'true' | 'false')}
+            className="text-black p-1 rounded"
+          >
+            <option value="all">All</option>
+            <option value="true">Approved</option>
+            <option value="false">Pending</option>
+          </select>
+        </div>
+        <div>
+          <label className="mr-2">Sort</label>
+          <select
+            value={sortOrder}
+            onChange={e => setSortOrder(e.target.value as 'newest' | 'oldest')}
+            className="text-black p-1 rounded"
+          >
+            <option value="newest">Newest</option>
+            <option value="oldest">Oldest</option>
+          </select>
+        </div>
+      </div>
+      {filteredArtists.length > 0 ? (
         <ul className="space-y-6">
-          {artists.map(a => (
+          {filteredArtists.map(a => (
             <li key={a.id} className="bg-white rounded-md shadow-md p-4">
               <AdminArtistCard
                 artist={a}

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -86,6 +86,7 @@ export interface Artist {
   stage_plot?: string;
   press_kit?: string;
   tip_jar_url?: string;
+  notes?: string;
   is_pro?: boolean;
   is_approved?: boolean;
   trial_active?: boolean;


### PR DESCRIPTION
## Summary
- add `notes` to the `Artist` interface
- support editing notes and quick actions in `AdminArtistCard`
- add filtering and sorting in `ArtistReview`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f550dbdb0832c9c2d0119835f0282