### PR TITLE
Add search and sharing tools for artists

### DIFF
--- a/src/pages/artists/[slug].tsx
+++ b/src/pages/artists/[slug].tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/context/AuthContext';
 import Header from '@/components/Header';
 import Link from 'next/link';
 import TrialBanner from '@/components/TrialBanner'; // adjust path as needed
+import { FaFacebookF, FaTwitter, FaLink, FaShareAlt } from 'react-icons/fa';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
@@ -126,8 +127,11 @@ if (shouldShowUpgradeWall) {
     <>
       <Head>
         <title>{artist.display_name} | Alpine Groove Guide</title>
-        <meta name="description" content={`See upcoming gigs and learn more about ${artist.display_name}`} />
+        <meta name="description" content={artist.bio?.slice(0, 150)} />
+        <meta property="og:title" content={`${artist.display_name} | Alpine Groove Guide`} />
+        <meta property="og:description" content={artist.bio?.slice(0, 150)} />
         <meta property="og:image" content={artist.profile_image} />
+        <meta property="og:url" content={`https://app.alpinegrooveguide.com/artists/${artist.slug}`} />
       </Head>
 
       <div className="min-h-screen bg-gray-900 text-white p-6">
@@ -183,6 +187,46 @@ if (shouldShowUpgradeWall) {
               >
                 {artist.website}
               </a></p>}
+              <div className="flex flex-wrap gap-2 mt-4">
+                <button
+                  onClick={() => {
+                    if (navigator.share) {
+                      navigator.share({
+                        title: artist.display_name,
+                        url: window.location.href,
+                      });
+                    }
+                  }}
+                  className="bg-yellow-500 hover:bg-yellow-600 text-black px-3 py-1 rounded shadow flex items-center gap-1"
+                >
+                  <FaShareAlt /> Share
+                </button>
+                <a
+                  href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded shadow flex items-center gap-1"
+                >
+                  <FaFacebookF /> Facebook
+                </a>
+                <a
+                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&text=${encodeURIComponent(artist.display_name)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-sky-500 hover:bg-sky-600 text-white px-3 py-1 rounded shadow flex items-center gap-1"
+                >
+                  <FaTwitter /> X
+                </a>
+                <button
+                  onClick={() => {
+                    navigator.clipboard.writeText(window.location.href);
+                    alert('Link copied to clipboard!');
+                  }}
+                  className="bg-gray-700 hover:bg-gray-800 text-white px-3 py-1 rounded shadow flex items-center gap-1"
+                >
+                  <FaLink /> Copy Link
+                </button>
+              </div>
             </div>
           </div>
 

--- a/src/pages/artists/index.tsx
+++ b/src/pages/artists/index.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Head from 'next/head';
 import Header from '@/components/Header';
-import { useAuth } from '@/context/AuthContext';
 import Image from 'next/image';
 
 interface Artist {
@@ -17,8 +16,17 @@ interface Artist {
 export default function ArtistDirectoryPage() {
   const [artists, setArtists] = useState<Artist[]>([]);
   const [loading, setLoading] = useState(true);
-  const { user } = useAuth();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [stateFilter, setStateFilter] = useState('');
+  const [zipFilter, setZipFilter] = useState('');
   const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+  const filteredArtists = artists.filter((artist) => {
+    const q = searchQuery.toLowerCase();
+    const matchesQuery =
+      artist.display_name.toLowerCase().includes(q) ||
+      artist.genres.join(', ').toLowerCase().includes(q);
+    return matchesQuery;
+  });
 
   useEffect(() => {
     const fetchArtists = async () => {
@@ -36,16 +44,6 @@ export default function ArtistDirectoryPage() {
     fetchArtists();
   }, [API_BASE_URL]);
 
-  // Admin-only gate
-  if (!user?.is_admin) {
-    return (
-      <div className="min-h-screen bg-gray-900 text-white p-6">
-        <Header />
-        <h1 className="text-3xl font-bold mb-6">🔒 Artist Directory</h1>
-        <p className="text-gray-400">This section is currently available to site admins only.</p>
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6">
@@ -66,12 +64,35 @@ export default function ArtistDirectoryPage() {
       </div>
 
       <h1 className="text-3xl font-bold mb-6">🎶 Artist Directory</h1>
+      <div className="flex flex-col md:flex-row gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Search by name or genre"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="p-2 rounded text-black flex-1"
+        />
+        <input
+          type="text"
+          placeholder="State (coming soon)"
+          value={stateFilter}
+          onChange={(e) => setStateFilter(e.target.value)}
+          className="p-2 rounded text-black md:w-40"
+        />
+        <input
+          type="text"
+          placeholder="Zip (coming soon)"
+          value={zipFilter}
+          onChange={(e) => setZipFilter(e.target.value)}
+          className="p-2 rounded text-black md:w-32"
+        />
+      </div>
 
       {loading ? (
         <p>Loading...</p>
       ) : (
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {artists.map((artist) => (
+          {filteredArtists.map((artist) => (
             <Link
               key={artist.slug}
               href={`/artists/${artist.slug}`}


### PR DESCRIPTION
## Summary
- make artist directory public
- add search bar and placeholder filters
- filter the list of artists on /artists
- improve SEO tags for artist pages
- add share buttons and copy link feature on artist profiles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f58d0ef08832c800a6ce0b32b0ce7