### PR TITLE
Add artist share page and update share links

### DIFF
--- a/src/pages/artists/[slug].tsx
+++ b/src/pages/artists/[slug].tsx
@@ -218,7 +218,7 @@ if (shouldShowUpgradeWall) {
                     if (navigator.share) {
                       navigator.share({
                         title: artist.display_name,
-                        url: window.location.href,
+                        url: `https://app.alpinegrooveguide.com/share/artist/${artist.slug}`,
                       });
                     }
                   }}
@@ -227,7 +227,9 @@ if (shouldShowUpgradeWall) {
                   <FaShareAlt /> Share
                 </button>
                 <a
-                  href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(window.location.href)}`}
+                  href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
+                    `https://app.alpinegrooveguide.com/share/artist/${artist.slug}`
+                  )}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded shadow flex items-center gap-1"
@@ -235,7 +237,9 @@ if (shouldShowUpgradeWall) {
                   <FaFacebookF /> Facebook
                 </a>
                 <a
-                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&text=${encodeURIComponent(artist.display_name)}`}
+                  href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(
+                    `https://app.alpinegrooveguide.com/share/artist/${artist.slug}`
+                  )}&text=${encodeURIComponent(artist.display_name)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="bg-sky-500 hover:bg-sky-600 text-white px-3 py-1 rounded shadow flex items-center gap-1"
@@ -244,7 +248,9 @@ if (shouldShowUpgradeWall) {
                 </a>
                 <button
                   onClick={() => {
-                    navigator.clipboard.writeText(window.location.href);
+                    navigator.clipboard.writeText(
+                      `https://app.alpinegrooveguide.com/share/artist/${artist.slug}`
+                    );
                     alert('Link copied to clipboard!');
                   }}
                   className="bg-gray-700 hover:bg-gray-800 text-white px-3 py-1 rounded shadow flex items-center gap-1"

--- a/src/pages/share/artist/[slug].tsx
+++ b/src/pages/share/artist/[slug].tsx
@@ -1,0 +1,61 @@
+// pages/share/artist/[slug].tsx
+import { getArtistBySlug } from "../../api/artists";
+
+export const getServerSideProps = async (context: any) => {
+  const slug = context.params?.slug;
+  let artist = null;
+  try {
+    artist = await getArtistBySlug(slug);
+  } catch (err) {
+    artist = null;
+  }
+
+  if (!artist) {
+    context.res.statusCode = 404;
+    context.res.end("Not Found");
+    return { props: {} };
+  }
+
+  const imageUrl = artist.profile_image?.startsWith("http")
+    ? artist.profile_image
+    : "https://app.alpinegrooveguide.com/alpine_groove_guide_icon.png";
+
+  const description =
+    artist.bio?.slice(0, 150) ||
+    "Discover live music across Colorado with Alpine Groove Guide.";
+
+  const html = `
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <title>${artist.display_name}</title>
+        <meta property="fb:app_id" content="1227448998748931" />
+        <meta property="og:title" content="${artist.display_name}" />
+        <meta property="og:description" content="${description}" />
+        <meta property="og:image" content="${imageUrl}" />
+        <meta property="og:image:type" content="image/jpeg" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:url" content="https://app.alpinegrooveguide.com/share/artist/${slug}" />
+        <meta property="og:type" content="article" />
+        <meta property="og:site_name" content="Alpine Groove Guide" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:image" content="${imageUrl}" />
+        <meta name="twitter:title" content="${artist.display_name}" />
+        <meta name="twitter:description" content="${description}" />
+        <meta http-equiv="refresh" content="1;url=/artists/${slug}" />
+      </head>
+      <body style="font-family:sans-serif;text-align:center;padding-top:2rem">
+        <p>Redirecting to <a href="/artists/${slug}">${artist.display_name}</a>...</p>
+      </body>
+    </html>
+  `;
+
+  context.res.setHeader("Content-Type", "text/html");
+  context.res.end(html);
+  return { props: {} };
+};
+
+export default function ShareArtistPage() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- implement `/share/artist/[slug].tsx` for OG and Twitter metadata with redirect
- update share buttons on artist profile page to use the new share route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f884cfb64832c82a3335a16241c10