### PR TITLE
Implement Alpine Pro trial upgrade flow

### DIFF
--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import React, { useState, useEffect, useRef } from "react";
 import Header from "@/components/Header";
 import Image from "next/image";
+import Link from 'next/link';
 import TrialBanner from '@/components/TrialBanner';
 import ActiveTrialNoProfileBanner from '@/components/ActiveTrialNoProfileBanner';
 import { isTrialActive } from '@/util/isTrialActive';
@@ -37,7 +38,7 @@ const UserProfile: React.FC = () => {
   const [hasRefetched, setHasRefetched] = useState(false);
   const trialActive = isTrialActive(user?.trial_ends_at);
   const trialStarted = Boolean(user?.trial_ends_at);
-  const [startingTrial, setStartingTrial] = useState(false);
+  const trialExpired = user && !user.is_pro && !!user.trial_ends_at && !trialActive;
   const [isApproved, setIsApproved] = useState<boolean | null>(null);
 
   // If redirected from Stripe, fetch updated user info
@@ -413,12 +414,18 @@ const UserProfile: React.FC = () => {
 
 {hasArtistProfile && (
   isApproved ? (
-    <button
-      onClick={() => router.push(`/artists/${artistSlug}`)}
-      className="bg-purple-600 hover:bg-purple-700 text-white py-2 rounded font-semibold"
-    >
-      Alpine Pro Dashboard
-    </button>
+    trialActive || user.is_pro ? (
+      <button
+        onClick={() => router.push(`/artists/${artistSlug}`)}
+        className="bg-purple-600 hover:bg-purple-700 text-white py-2 rounded font-semibold"
+      >
+        Alpine Pro Dashboard
+      </button>
+    ) : (
+      <Link href="/upgrade" className="underline text-blue-300">
+        Upgrade to Alpine Pro
+      </Link>
+    )
   ) : (
     <div className="bg-yellow-100 text-yellow-900 border border-yellow-400 p-4 rounded shadow-md text-sm">
       <p className="font-semibold mb-2">🎷 Your artist profile is under review</p>

--- a/src/pages/api/create-checkout-session.ts
+++ b/src/pages/api/create-checkout-session.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  try {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/create-checkout-session`, {
+      method: 'POST',
+      headers: {
+        cookie: req.headers.cookie || '',
+      },
+    });
+
+    const data = await response.json();
+    res.status(response.status).json({ session: data });
+  } catch (err) {
+    console.error('Checkout session error', err);
+    res.status(500).json({ message: 'Failed to create session' });
+  }
+}

--- a/src/pages/artist-signup.tsx
+++ b/src/pages/artist-signup.tsx
@@ -11,7 +11,7 @@ const topGenres = [
 ];
 
 export default function ArtistSignupPage() {
-  const { user } = useAuth();
+  const { user, refetchUser } = useAuth();
   const router = useRouter();
 
   const trialActive = isTrialActive(user?.trial_ends_at);
@@ -115,7 +115,8 @@ export default function ArtistSignupPage() {
 
       if (!res.ok) throw new Error('Failed to create artist profile');
 
-      const data = await res.json();
+      await res.json();
+      await refetchUser();
       router.push(`/UserProfile?trial=active`);
     } catch (err: any) {
       setError(err.message);

--- a/src/pages/upgrade.tsx
+++ b/src/pages/upgrade.tsx
@@ -1,8 +1,28 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import Header from '@/components/Header';
+import { useState } from 'react';
 
 export default function UpgradePage() {
+  const [loading, setLoading] = useState(false);
+
+  const handleSubscribe = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/create-checkout-session', {
+        method: 'POST',
+      });
+      const data = await res.json();
+      if (data.session?.url) {
+        window.location.href = data.session.url;
+      }
+    } catch (err) {
+      console.error('Checkout error', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-900 text-white flex flex-col">
       <Head>
@@ -15,18 +35,14 @@ export default function UpgradePage() {
           Alpine Pro members can create public artist profiles, submit unlimited events, and access exclusive features.
         </p>
         <p className="mb-6 max-w-xl">
-          Stripe checkout is coming soon. In the meantime,{' '}
-          <a href="mailto:poole.reid@gmail.com" className="underline text-yellow-300 hover:text-yellow-200">
-            contact us
-          </a>{' '}
-          to upgrade manually.
+          Ready to continue using all Alpine Pro features? Subscribe below and you’ll be redirected to Stripe Checkout.
         </p>
-        {/* TODO: Replace with Stripe checkout button */}
         <button
-          disabled
-          className="bg-gray-700 text-gray-400 px-6 py-3 rounded font-semibold cursor-not-allowed"
+          onClick={handleSubscribe}
+          disabled={loading}
+          className="bg-green-600 hover:bg-green-700 px-6 py-3 rounded font-semibold text-white disabled:opacity-50"
         >
-          Stripe Checkout Coming Soon
+          {loading ? 'Redirecting…' : 'Subscribe'}
         </button>
       </main>
       <footer className="text-center text-sm text-gray-500 py-4">


### PR DESCRIPTION
## Summary
- refresh user data after creating an artist profile
- gate Alpine Pro dashboard button and link to upgrade when trial expired
- add Stripe checkout subscription button
- create API route to start checkout session

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9290de04832c9180798d5a180150