### PR TITLE
Add upgrade entry points

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai';
 import Image from 'next/image';
+import { useAuth } from '@/context/AuthContext';
 
 const Header = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const { user } = useAuth();
 
   const toggleMenu = () => setMenuOpen(!menuOpen);
 
@@ -41,6 +43,14 @@ const Header = () => {
           <Link href="/about" className="block lg:inline-block text-white hover:text-gold transition">
             About Us
           </Link>
+          {user && !user.is_pro && (
+            <Link
+              href="/upgrade"
+              className="block lg:inline-block text-white hover:text-gold transition"
+            >
+              Upgrade to Pro
+            </Link>
+          )}
         </nav>
       </div>
     </header>

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -279,6 +279,23 @@ const UserProfile: React.FC = () => {
           ✅ Welcome! Your 30-day free trial of Alpine Pro is active.
         </div>
       )}
+      {!user.is_pro && (
+        <div className="text-center mb-4">
+          {trialActive ? (
+            <Link href="/upgrade">
+              <button className="bg-purple-600 hover:bg-purple-700 text-white py-2 px-4 rounded font-semibold">
+                Upgrade early to support us
+              </button>
+            </Link>
+          ) : trialExpired ? (
+            <Link href="/upgrade">
+              <button className="bg-purple-600 hover:bg-purple-700 text-white py-2 px-4 rounded font-semibold">
+                Upgrade to continue using Pro features
+              </button>
+            </Link>
+          ) : null}
+        </div>
+      )}
       <div className="max-w-5xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-6 flex items-center gap-3">
           🎤 Profile: {user.displayName}


### PR DESCRIPTION
## Summary
- add upgrade button to header when user isn't Pro
- prompt early upgrade on UserProfile for trialing users

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f957b0efc832c97396864039aef7a