### PR TITLE
Update blur rule for artist profiles

### DIFF
--- a/src/pages/artists/[slug].tsx
+++ b/src/pages/artists/[slug].tsx
@@ -61,12 +61,7 @@ const ArtistProfilePage = ({ artist }: Props) => {
   const showPendingBanner = isPending && isOwner && artist && artist.is_approved === false;
   const [showTrialToast, setShowTrialToast] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const today = dayjs(); // make sure dayjs is imported
-  const trialEnded = artist?.trial_ends_at && dayjs(artist?.trial_ends_at).isBefore(today);
-  const isTrialExpired = trialEnded && !artist.is_pro;
-  const isProfileOwner = user?.id === artist?.user_id; // You must pass this in from context or props
-
-  const shouldBlur = isTrialExpired && !isProfileOwner;
+  const shouldBlur = !artist.is_pro && !(isOwner || user?.is_admin);
 
   useEffect(() => {
     if (router.query.trial === 'active') {


### PR DESCRIPTION
## Summary
- blur private artist details whenever they aren't a pro unless owner or admin

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586ddd78dc832c826dd5bdfbbd7063