### PR TITLE
Fix null check on artist profile

### DIFF
--- a/src/pages/artists/[slug].tsx
+++ b/src/pages/artists/[slug].tsx
@@ -65,7 +65,7 @@ const ArtistProfilePage = ({ artist }: Props) => {
   const isTrialExpired =
     !!artist?.trial_ends_at && dayjs().isAfter(dayjs(artist.trial_ends_at));
 
-  const shouldBlur = isTrialExpired && !artist.is_pro && !isProfileOwner;
+  const shouldBlur = isTrialExpired && !(artist?.is_pro) && !isProfileOwner;
 
   useEffect(() => {
     if (router.query.trial === 'active') {


### PR DESCRIPTION
## Summary
- handle nullable `artist` when checking pro status in `[slug].tsx`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685874ae97bc832c9ec83dc3177c232c