### PR TITLE
Fix blur logic based on trial status

### DIFF
--- a/src/pages/artists/[slug].tsx
+++ b/src/pages/artists/[slug].tsx
@@ -66,7 +66,8 @@ const ArtistProfilePage = ({ artist }: Props) => {
     !!artist?.trial_ends_at && dayjs().isAfter(dayjs(artist?.trial_ends_at));
 
   // const shouldBlur = isTrialExpired && !artist.is_pro && !isProfileOwner;
-  const shouldBlur = !artist?.is_pro && !(isOwner || user?.is_admin);
+  const shouldBlur =
+    isTrialExpired && !artist?.is_pro && !(isOwner || user?.is_admin);
 
   useEffect(() => {
     if (router.query.trial === 'active') {


### PR DESCRIPTION
## Summary
- only blur artist info when the trial period has ended and the viewer isn't the owner or an admin

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861efad8f70832cb67d2148a77ceed6