### PR TITLE
Remove unused truncate import

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,3 @@
-const { truncate } = require('fs');
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
    // 🚧  Disable React-Strict-Mode while we hunt the mismatch


### PR DESCRIPTION
## Summary
- drop unused truncate import from `next.config.js`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f00548b0832caa251156f9e11094