### PR TITLE
Add pro cancellation tracking and helper

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -68,6 +68,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       top_music_genres: parseGenres(data.user.top_music_genres),
       profile_picture: profilePicData.profile_picture_url || null,
       trial_ends_at: data.user.trial_ends_at || null,
+      // Parse and include `pro_cancelled_at` in the user context so we can check if Pro access is still valid.
+      pro_cancelled_at: data.user.pro_cancelled_at || null,
     };
   }, []);
 
@@ -119,6 +121,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       top_music_genres: genres,
       profile_picture: profileData.profile_picture_url,
       trial_ends_at: data.user.trial_ends_at || null,
+      // Add `pro_cancelled_at` so we can determine if Pro access is still valid after cancellation.
+      pro_cancelled_at: data.user.pro_cancelled_at || null,
     };
 
     setUser(fullUser);

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -7,7 +7,9 @@ export interface UserType {
   password?: string;
   is_admin: boolean;
   is_logged_in?: boolean;
-  is_pro?: boolean; 
+  is_pro?: boolean;
+  // Add `pro_cancelled_at` to track when Pro access expires after cancellation.
+  pro_cancelled_at?: string | null;
   trial_ends_at?: string | null;
   top_music_genres: string[];
   user_description?: string;

--- a/src/util/isActivePro.ts
+++ b/src/util/isActivePro.ts
@@ -1,0 +1,4 @@
+export const isActivePro = (user: import("../types").UserType): boolean => {
+  const expires = user?.pro_cancelled_at ? new Date(user.pro_cancelled_at) : null;
+  return !!user?.is_pro && (!expires || expires > new Date());
+};


### PR DESCRIPTION
## Summary
- include `pro_cancelled_at` in `UserType`
- parse `pro_cancelled_at` in `AuthContext`
- add `isActivePro` helper to check ongoing Pro access

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_687d127ae1ac832c8de5528b86e7d76f