### PR TITLE
Fix gating to use unified Pro check

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,10 +3,12 @@ import Link from 'next/link';
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai';
 import Image from 'next/image';
 import { useAuth } from '@/context/AuthContext';
+import { isActivePro } from '@/util/isActivePro';
 
 const Header = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { user } = useAuth();
+  const proActive = isActivePro(user as any);
 
   const toggleMenu = () => setMenuOpen(!menuOpen);
 
@@ -43,7 +45,7 @@ const Header = () => {
           <Link href="/about" className="block lg:inline-block text-white hover:text-gold transition">
             About Us
           </Link>
-          {user && !user.is_pro && user.is_admin && (
+          {user && !proActive && user.is_admin && (
             <Link
               href="/upgrade"
               className="block lg:inline-block text-white hover:text-gold transition"

--- a/src/components/TrialBanner.tsx
+++ b/src/components/TrialBanner.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import Link from 'next/link';
 import { useAuth } from '@/context/AuthContext';
+import { isActivePro } from '@/util/isActivePro';
 
 interface TrialBannerProps {
   trial_ends_at?: string | null;
@@ -14,7 +15,7 @@ const TrialBanner: React.FC<TrialBannerProps> = (props) => {
   const isProfileOwner = user?.id === props.artist_user_id;
 
   const trialEndStr = props.trial_ends_at ?? user?.trial_ends_at;
-  const isPro = props.is_pro ?? user?.is_pro;
+  const isPro = props.is_pro ?? isActivePro(user as any);
 
   const [daysLeft, setDaysLeft] = useState<number | null>(null);
 

--- a/src/pages/UserProfile.tsx
+++ b/src/pages/UserProfile.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import TrialBanner from '@/components/TrialBanner';
 import ActiveTrialNoProfileBanner from '@/components/ActiveTrialNoProfileBanner';
 import { isTrialActive } from '@/util/isTrialActive';
+import { isActivePro } from '@/util/isActivePro';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -38,7 +39,8 @@ const UserProfile: React.FC = () => {
   const [hasRefetched, setHasRefetched] = useState(false);
   const trialActive = isTrialActive(user?.trial_ends_at);
   const trialStarted = Boolean(user?.trial_ends_at);
-  const trialExpired = user && !user.is_pro && !!user.trial_ends_at && !trialActive;
+  const proActive = isActivePro(user as any);
+  const trialExpired = user && !proActive && !!user.trial_ends_at && !trialActive;
   const [isApproved, setIsApproved] = useState<boolean | null>(null);
   const [formError, setFormError] = useState("");
 
@@ -319,7 +321,7 @@ const UserProfile: React.FC = () => {
           ✅ Welcome! Your 30-day free trial of Alpine Pro is active.
         </div>
       )}
-      {!user.is_pro && (
+      {!proActive && (
         <div className="text-center mb-4">
           {trialActive ? (
             <Link href="/upgrade">
@@ -339,7 +341,7 @@ const UserProfile: React.FC = () => {
       <div className="max-w-5xl mx-auto p-6">
         <h1 className="text-3xl font-bold mb-6 flex items-center gap-3">
           🎤 Profile: {user.displayName}
-          {user.is_pro && (
+          {proActive && (
             <div className="inline-block bg-green-600 text-white text-xs font-bold px-3 py-1 rounded-full">
               Alpine Pro Member
             </div>
@@ -452,7 +454,7 @@ const UserProfile: React.FC = () => {
               >
                 Back to Home
               </button>
-              {user?.is_pro && (
+              {proActive && (
                 <button
                   onClick={handleManageBilling}
                   className="bg-red-600 hover:bg-red-700 text-white py-2 rounded font-semibold"
@@ -481,7 +483,7 @@ const UserProfile: React.FC = () => {
 
               {hasArtistProfile && (
                 isApproved ? (
-                  trialActive || user.is_pro ? (
+                  trialActive || proActive ? (
                     <button
                       onClick={() => router.push(`/artists/${artistSlug}`)}
                       className="bg-purple-600 hover:bg-purple-700 text-white py-2 rounded font-semibold"

--- a/src/pages/artist-signup.tsx
+++ b/src/pages/artist-signup.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useAuth } from '@/context/AuthContext';
 import TrialBanner from '@/components/TrialBanner';
 import { isTrialActive } from '@/util/isTrialActive';
+import { isActivePro } from '@/util/isActivePro';
 
 const topGenres = [
   'Jazz', 'Rock', 'Pop', 'Hip-Hop', 'R&B', 'Electronic',
@@ -15,7 +16,8 @@ export default function ArtistSignupPage() {
   const router = useRouter();
 
   const trialActive = isTrialActive(user?.trial_ends_at);
-  const trialExpired = user && !user.is_pro && !!user.trial_ends_at && !trialActive;
+  const proActive = isActivePro(user as any);
+  const trialExpired = user && !proActive && !!user.trial_ends_at && !trialActive;
 
   const [form, setForm] = useState({
     display_name: '',
@@ -128,7 +130,7 @@ export default function ArtistSignupPage() {
   if (trialExpired) {
     return (
       <div className="max-w-xl mx-auto p-6 text-white text-center">
-        <TrialBanner trial_ends_at={user!.trial_ends_at} is_pro={user!.is_pro} />
+        <TrialBanner trial_ends_at={user!.trial_ends_at} />
         <p className="mb-4">Your free trial has expired. Upgrade to Alpine Pro to manage an artist profile.</p>
         <Link href="/upgrade" className="text-blue-400 underline">Upgrade Now</Link>
       </div>
@@ -137,7 +139,7 @@ export default function ArtistSignupPage() {
 
   return (
     <div className="max-w-xl mx-auto p-6 text-white">
-      <TrialBanner trial_ends_at={user?.trial_ends_at} is_pro={user?.is_pro} />
+      <TrialBanner trial_ends_at={user?.trial_ends_at} />
       <h1 className="text-2xl font-bold mb-2">🎤 Claim Your Artist Profile</h1>
       <p className="text-sm text-gray-300 mb-4">
         Create your public artist profile and enjoy 30 days of Alpine Pro access free.

--- a/src/pages/artists/edit/[slug].tsx
+++ b/src/pages/artists/edit/[slug].tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useAuth } from '@/context/AuthContext';
 import TrialBanner from '@/components/TrialBanner';
 import { isTrialActive } from '@/util/isTrialActive';
+import { isActivePro } from '@/util/isActivePro';
 
 const topGenres = [
   'Jazz', 'Rock', 'Pop', 'Hip-Hop', 'R&B', 'Electronic',
@@ -17,7 +18,8 @@ export default function EditArtistProfilePage() {
   const { user } = useAuth();
 
   const trialActive = isTrialActive(user?.trial_ends_at);
-  const trialExpired = user && !user.is_pro && !!user.trial_ends_at && !trialActive;
+  const proActive = isActivePro(user as any);
+  const trialExpired = user && !proActive && !!user.trial_ends_at && !trialActive;
 
   const [form, setForm] = useState({
     display_name: '',
@@ -140,7 +142,7 @@ export default function EditArtistProfilePage() {
   if (trialExpired) {
     return (
       <div className="max-w-xl mx-auto p-6 text-white text-center">
-        <TrialBanner trial_ends_at={user!.trial_ends_at} is_pro={user!.is_pro} />
+        <TrialBanner trial_ends_at={user!.trial_ends_at} />
         <p className="mb-4">Your free trial has expired. Upgrade to Alpine Pro to edit your artist profile.</p>
         <Link href="/upgrade" className="text-blue-400 underline">Upgrade Now</Link>
       </div>
@@ -150,7 +152,7 @@ export default function EditArtistProfilePage() {
 
   return (
     <div className="max-w-xl mx-auto p-6 text-white">
-      <TrialBanner trial_ends_at={user?.trial_ends_at} is_pro={user?.is_pro} />
+      <TrialBanner trial_ends_at={user?.trial_ends_at} />
       <h1 className="text-2xl font-bold mb-4">Edit Artist Profile</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <input name="display_name" value={form.display_name} onChange={handleChange} placeholder="Display Name" className="w-full p-2 rounded bg-gray-800 border border-gray-600" />

--- a/src/pages/artists/index.tsx
+++ b/src/pages/artists/index.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import Header from '@/components/Header';
 import Image from 'next/image';
 import { isTrialActive } from '@/util/isTrialActive';
+import { isActivePro } from '@/util/isActivePro';
 import { useAuth } from '@/context/AuthContext';
 
 interface Artist {
@@ -60,7 +61,7 @@ export default function ArtistDirectoryPage() {
       <div className="mb-6 bg-indigo-800 text-white p-4 rounded-xl shadow-xl text-center">
         <h2 className="text-2xl font-bold">🎙️ Discover Local Talent</h2>
         <p className="text-gray-200">Browse Alpine Pro artists and support your local scene.</p>
-        {!user?.is_pro && !isTrialActive(user?.trial_ends_at) && (
+        {!isActivePro(user as any) && !isTrialActive(user?.trial_ends_at) && (
           <Link href="/upgrade">
             <button className="mt-3 bg-green-600 hover:bg-green-700 text-white px-5 py-2 rounded font-semibold">
               Become an Alpine Pro Artist →

--- a/src/pages/eventSubmission.tsx
+++ b/src/pages/eventSubmission.tsx
@@ -9,6 +9,7 @@ import { slugify } from '@/util/slugify'; // Adjust path if needed
 import EventForm from '../components/EventForm';
 import TrialBanner from '@/components/TrialBanner';
 import { isTrialActive } from '@/util/isTrialActive';
+import { isActivePro } from '@/util/isActivePro';
 
 interface Event {
   title: string;
@@ -63,10 +64,10 @@ const EventSubmission = () => {
   const locationInputRefs = useRef<(HTMLInputElement | null)[]>([]);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
-  const isPro = user?.is_pro;
+  const proActive = isActivePro(user as any);
   const trialActive = isTrialActive(user?.trial_ends_at);
-  const canAddMultiple = Boolean(isPro || trialActive);
-  const trialExpired = user && !isPro && !!user.trial_ends_at && !trialActive;
+  const canAddMultiple = Boolean(proActive || trialActive);
+  const trialExpired = user && !proActive && !!user.trial_ends_at && !trialActive;
 
   const addEvent = () => setEvents((prev) => [...prev, { ...initialEvent }]);
   const removeEvent = (index: number) =>
@@ -312,7 +313,7 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
   if (trialExpired) {
     return (
       <div className="container mx-auto p-4 text-center text-white">
-        <TrialBanner trial_ends_at={user!.trial_ends_at} is_pro={user!.is_pro} />
+        <TrialBanner trial_ends_at={user!.trial_ends_at} />
         <p className="mb-4">Your free trial has expired. Upgrade to Alpine Pro to submit events.</p>
         <Link href="/upgrade" className="text-blue-500 underline">
           Upgrade Now
@@ -336,7 +337,7 @@ const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 
   return user ? (
     <div className="container mx-auto p-4">
-      <TrialBanner trial_ends_at={user.trial_ends_at} is_pro={user.is_pro} />
+      <TrialBanner trial_ends_at={user.trial_ends_at} />
       <Script
         src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places`}
         strategy="lazyOnload"


### PR DESCRIPTION
## Summary
- use new `isActivePro` helper across pages
- compute Pro status in `Header`, event submission and profile components
- drop redundant `is_pro` props for `TrialBanner`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814ca5a0c8832cbe83a7e5b1eaaa90